### PR TITLE
disable HostCheck

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  devServer: {
+    disableHostCheck: true
+  }
+}


### PR DESCRIPTION
In the eclipse che IDE environment, 
the domain used by vue-js  is not 127.0.0.1, 
but a randomly generated domain name, 
so it will throw `invalid host header` error.

Solution: Turn off `disableHostCheck` option